### PR TITLE
docs: add proguard annotation to quickstart

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -92,6 +92,15 @@ For advanced setup please refer to [cookbook](./cookbook.md)
          }
          ```
 
+      3. If you are using ProGuard:
+         in `proguard-rules.pro` add
+
+         ```java
+         -keepclassmembers class [YOUR_GOOGLE_APPLICATION_NAME].BuildConfig {
+            public static <fields>;
+         }
+         ```
+
 1) save changes made to navite projects `.xcodeproj` file and `build.gradle`.
    **DO NOT COMMMIT** `rnuc.*` files.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -96,7 +96,7 @@ For advanced setup please refer to [cookbook](./cookbook.md)
          in `proguard-rules.pro` add
 
          ```java
-         -keepclassmembers class [YOUR_GOOGLE_APPLICATION_NAME].BuildConfig {
+         -keepclassmembers class <APPLICATION ID>.BuildConfig {
             public static <fields>;
          }
          ```


### PR DESCRIPTION
Addresses Proguard build difficulty in #17 

How to test:
Follow instructions in quickstart
Build in android release mode, with proguard minifyEnabled on
App should work normally