### PR TITLE
fix(android): look up yamls against project root

### DIFF
--- a/android/rnuc.gradle
+++ b/android/rnuc.gradle
@@ -39,7 +39,8 @@ def buildRootConfig() {
         def flavorMapping = project.ext.get('flavorEnvMapping')
         println "Flavor mapping detected: ${flavorMapping}"
         flavorMapping.each { flavor, yamlPath -> 
-            config.put(flavor, readYaml(Paths.get(yamlPath)))
+            def absolutePath = Paths.get(project.rootDir.getAbsolutePath(), yamlPath)
+            config.put(flavor, readYaml(absolutePath))
         }
         return config
     } else {


### PR DESCRIPTION
rely on `project.rootDir` when constructing a path for mapped configuration
files.

issue mentioned in
https://github.com/maxkomarychev/react-native-ultimate-config/issues/27
has been caused by the fact that current working directory of gradle
process was root of the repository and project root has been specified
via `-p, --project-dir` flag. this resulted in relative paths being
resolved against root of the repository instead of "android" folder.