### PR TITLE
fix: prevent comments in xcconfig

### DIFF
--- a/src/__tests__/outputs/rnuc.xcconfig
+++ b/src/__tests__/outputs/rnuc.xcconfig
@@ -1,6 +1,6 @@
 // DO NOT COMMIT OR EDIT THIS FILE
 MY_VARIABLE=hello
-MY_URL=http://hello.world?howareyoudoing=ok
+MY_URL=http:/$()/hello.world?howareyoudoing=ok
 MY_STRING=string_value
 MY_NUMBER=42
 MY_BOOLEAN=true

--- a/src/render-env.js
+++ b/src/render-env.js
@@ -25,6 +25,14 @@ function escape(value) {
   }
 }
 
+function xcconfig_format(value) {
+  if (is_string(value)) {
+    return value.replace(/\/\//gm, '\/$()\/');
+  } else {
+    return value;
+  }
+}
+
 function render_template(template_name, data) {
   const template_path = path.join(
     __dirname,
@@ -36,6 +44,7 @@ function render_template(template_name, data) {
   handlebars.registerHelper("isString", is_string);
   handlebars.registerHelper("isNumber", is_number);
   handlebars.registerHelper("escape", escape);
+  handlebars.registerHelper("xcconfigFormat", xcconfig_format);
   const parsed_template = handlebars.compile(template_string);
   const rendered = parsed_template(data);
   return rendered;

--- a/src/templates/rnuc.xcconfig.handlebars
+++ b/src/templates/rnuc.xcconfig.handlebars
@@ -1,4 +1,4 @@
 // DO NOT COMMIT OR EDIT THIS FILE
 {{#each @root}}
-{{@key}}={{{this}}}
+{{@key}}={{{xcconfigFormat this}}}
 {{/each}}


### PR DESCRIPTION
## Context

When adding url's to the rnuc config setup, they arrive correctly on the Android and JS side, but get cut off on the iOS side. For example, `https://www.github.com` will show up as `https:`. This is because the `//` is interpreted as a comment special character. The most used solution seems to inject `$()` in between the two forward slashes to break them up without actually changing the output string. 

See for example:

- https://stackoverflow.com/questions/21317844/how-do-i-configure-full-urls-in-xcconfig-files
- https://github.com/luggit/react-native-config/pull/374

## Changes

- Adds a new handlebar helper to escape forward slashes.
- Implements the helper in the xcconfig template.
- Updates the test template to reflect the desired outcome.