### PR TITLE
fix: add default `override` file

### DIFF
--- a/override.js
+++ b/override.js
@@ -1,0 +1,7 @@
+const RN = require("react-native");
+
+const IOS_DATA = {}
+
+const ANDROID_DATA = {}
+
+module.exports = {}


### PR DESCRIPTION
It prevents errors after re-installing dependencies 

<img width="487" alt="Screen Shot 2021-04-23 at 3 37 57 PM" src="https://user-images.githubusercontent.com/2099820/115879749-4bbaca80-a44a-11eb-910d-64876d3ee6d4.png">
