### PR TITLE
Fix native apps using web configuration

### DIFF
--- a/packages/react-native-ultimate-config/package.json
+++ b/packages/react-native-ultimate-config/package.json
@@ -4,6 +4,7 @@
   "version": "3.4.1",
   "description": "Config that works",
   "main": "index.js",
+  "react-native": "index.js",
   "browser": "index.web.js",
   "files": [
     "src/*.js",


### PR DESCRIPTION
This PR should fix #76, but I haven't been able to test that it doesn't break configuration for `react-native-web` projects, as I have been unable to set that up. As far as I know, `react-native-web` projects don't use Metro for bundling, and this `react-native` key is specific to Metro, so it should be fine.