### PR TITLE
fix: replace deprecated classifier property

### DIFF
--- a/packages/react-native-ultimate-config/android/build.gradle
+++ b/packages/react-native-ultimate-config/android/build.gradle
@@ -114,7 +114,7 @@ if (isNewArchitectureEnabled()) {
 
 afterEvaluate { project ->
   task androidSourcesJar(type: Jar) {
-    classifier = 'sources'
+    archiveClassifier = 'sources'
     from android.sourceSets.main.java.srcDirs
     include '**/*.java'
   }


### PR DESCRIPTION
The `classifier` property of `Jar` has been deprecated few major versions back, and no longer supported in the newest Gradle 8.0. Replace `classifier` with `archiveClassifier` as suggested in docs: https://docs.gradle.org/7.6/dsl/org.gradle.api.tasks.bundling.Jar.html#org.gradle.api.tasks.bundling.Jar:classifier

Fix: https://github.com/maxkomarychev/react-native-ultimate-config/issues/135